### PR TITLE
Rename major() and minor() methods.

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -1,5 +1,5 @@
 
-name: doxygen
+name: doxygen-build-commit-push
 
 on:
   push:

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -1,7 +1,8 @@
 
-name: doxygen
+name: doxygen-build-only
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ devel ]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 Forthcoming
 -----------
 * [demos] log levels demo added, `#42 <https://github.com/kobuki-base/kobuki_core/issues/42>`_
+* [driver] bugfix major, minor, patch macro conflicts, `#44 <https://github.com/kobuki-base/kobuki_core/issues/44>`_
 
 1.3.1 (2020-09-15)
 ------------------

--- a/include/kobuki_core/packets/firmware.hpp
+++ b/include/kobuki_core/packets/firmware.hpp
@@ -51,9 +51,9 @@ public:
   void showMe() {}
 
   const uint32_t& version() const { return data.version; }
-  int majorVersion() const { return VersionInfo::major(data.version); }
-  int minorVersion() const { return VersionInfo::minor(data.version); }
-  int patchVersion() const { return VersionInfo::patch(data.version); }
+  int majorVersion() const { return VersionInfo::majorVersion(data.version); }
+  int minorVersion() const { return VersionInfo::minorVersion(data.version); }
+  int patchVersion() const { return VersionInfo::patchVersion(data.version); }
 
   int checkMajorVersion() const;
   int checkRecommendedVersion() const;

--- a/include/kobuki_core/version_info.hpp
+++ b/include/kobuki_core/version_info.hpp
@@ -54,15 +54,15 @@ public:
   const uint32_t udid1;
   const uint32_t udid2;
 
-  static int major(const uint32_t &version) {
+  static int majorVersion(const uint32_t &version) {
     return ((version & 0x00FF0000) >> 16);
   }
 
-  static int minor(const uint32_t &version) {
+  static int minorVersion(const uint32_t &version) {
     return ((version & 0x0000FF00) >> 8);
   }
 
-  static int patch(const uint32_t &version) {
+  static int patchVersion(const uint32_t &version) {
     return (version & 0x000000FF);
   }
 
@@ -70,7 +70,7 @@ public:
   {
     // Convert an unsigned int into a string of type <major>.<minor>.<patch>; first byte is ignored
     std::stringstream ss;
-    ss << major(version) << "." << minor(version) << "." << patch(version);
+    ss << majorVersion(version) << "." << minorVersion(version) << "." << patchVersion(version);
     return std::string(ss.str());
   }
 

--- a/src/driver/firmware.cpp
+++ b/src/driver/firmware.cpp
@@ -103,9 +103,9 @@ int Firmware::checkRecommendedVersion() const
 
   // if flashed version is > all recommended versions, return 1, else -1
   for ( uint32_t version : RECOMMENDED_VERSIONS ) {
-    int recommended_major_version = VersionInfo::major(version);
-    int recommended_minor_version = VersionInfo::minor(version);
-    int recommended_patch_version = VersionInfo::patch(version);
+    int recommended_major_version = VersionInfo::majorVersion(version);
+    int recommended_minor_version = VersionInfo::minorVersion(version);
+    int recommended_patch_version = VersionInfo::patchVersion(version);
     if ( majorVersion() > recommended_major_version ) {
       continue;
     } else if ( majorVersion() < recommended_major_version ) {


### PR DESCRIPTION
Certain version of glibc on Linux use a macro for the device
major and minor numbers.  When that happens, it directly conflicts
with the name of these methods and causes a build failure.
Sidestep the whole issue by renaming the methods here to
"majorNum" and "minorNum".

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>