### PR TITLE
Add in workaround for compiling on aarch64.

### DIFF
--- a/include/kobuki_core/dock_drive.hpp
+++ b/include/kobuki_core/dock_drive.hpp
@@ -22,7 +22,21 @@
 #include <iomanip>
 #include <cmath>
 #include <vector>
+// Version 3.4.0 of Eigen in Ubuntu 22.04 has a bug that causes -Wclass-memaccess warnings on
+// aarch64.  Upstream Eigen has already fixed this in
+// https://gitlab.com/libeigen/eigen/-/merge_requests/645 .  The Debian fix for this is in
+// https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
+// However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
+// freezes, so disable the warning here.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 #include <ecl/geometry.hpp>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 #include <ecl/linear_algebra.hpp>
 
 /*****************************************************************************

--- a/include/kobuki_core/kobuki.hpp
+++ b/include/kobuki_core/kobuki.hpp
@@ -24,7 +24,21 @@
 #include <ecl/devices.hpp>
 #include <ecl/threads/mutex.hpp>
 #include <ecl/exceptions/standard_exception.hpp>
+// Version 3.4.0 of Eigen in Ubuntu 22.04 has a bug that causes -Wclass-memaccess warnings on
+// aarch64.  Upstream Eigen has already fixed this in
+// https://gitlab.com/libeigen/eigen/-/merge_requests/645 .  The Debian fix for this is in
+// https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
+// However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
+// freezes, so disable the warning here.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 #include <ecl/geometry.hpp>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 #include "version_info.hpp"
 
 #include "logging.hpp"

--- a/include/kobuki_core/modules/diff_drive.hpp
+++ b/include/kobuki_core/modules/diff_drive.hpp
@@ -20,7 +20,21 @@
 #include <vector>
 #include <climits>
 #include <stdint.h>
+// Version 3.4.0 of Eigen in Ubuntu 22.04 has a bug that causes -Wclass-memaccess warnings on
+// aarch64.  Upstream Eigen has already fixed this in
+// https://gitlab.com/libeigen/eigen/-/merge_requests/645 .  The Debian fix for this is in
+// https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
+// However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
+// freezes, so disable the warning here.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 #include <ecl/geometry.hpp>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 #include <ecl/mobile_robot.hpp>
 #include <ecl/threads/mutex.hpp>
 #include "../macros.hpp"

--- a/src/demos/simple_loop.cpp
+++ b/src/demos/simple_loop.cpp
@@ -17,7 +17,21 @@
 #include <string>
 
 #include <csignal>
+// Version 3.4.0 of Eigen in Ubuntu 22.04 has a bug that causes -Wclass-memaccess warnings on
+// aarch64.  Upstream Eigen has already fixed this in
+// https://gitlab.com/libeigen/eigen/-/merge_requests/645 .  The Debian fix for this is in
+// https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
+// However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
+// freezes, so disable the warning here.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 #include <ecl/geometry.hpp>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 #include <ecl/time.hpp>
 #include <ecl/sigslots.hpp>
 #include <ecl/linear_algebra.hpp>

--- a/src/driver/kobuki.cpp
+++ b/src/driver/kobuki.cpp
@@ -14,11 +14,24 @@
 #include <stdexcept>
 
 #include <ecl/math.hpp>
+// Version 3.4.0 of Eigen in Ubuntu 22.04 has a bug that causes -Wclass-memaccess warnings on
+// aarch64.  Upstream Eigen has already fixed this in
+// https://gitlab.com/libeigen/eigen/-/merge_requests/645 .  The Debian fix for this is in
+// https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
+// However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
+// freezes, so disable the warning here.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 #include <ecl/geometry/angle.hpp>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 #include <ecl/time/sleep.hpp>
 #include <ecl/converters.hpp>
 #include <ecl/sigslots.hpp>
-#include <ecl/geometry/angle.hpp>
 #include <ecl/time/timestamp.hpp>
 
 #include "../../include/kobuki_core/kobuki.hpp"

--- a/src/tools/simple_keyop.cpp
+++ b/src/tools/simple_keyop.cpp
@@ -17,7 +17,21 @@
 
 #include <ecl/command_line.hpp>
 #include <ecl/console.hpp>
+// Version 3.4.0 of Eigen in Ubuntu 22.04 has a bug that causes -Wclass-memaccess warnings on
+// aarch64.  Upstream Eigen has already fixed this in
+// https://gitlab.com/libeigen/eigen/-/merge_requests/645 .  The Debian fix for this is in
+// https://salsa.debian.org/science-team/eigen3/-/merge_requests/1 .
+// However, it is not clear that that fix is going to make it into Ubuntu 22.04 before it
+// freezes, so disable the warning here.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 #include <ecl/geometry.hpp>
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
 #include <ecl/linear_algebra.hpp>
 #include <ecl/time.hpp>
 #include <ecl/threads.hpp>


### PR DESCRIPTION
Ideally this would be in the ecl_core repository, but since we don't have write access there for now we just do it here where we need.