### PR TITLE
[docs] point to archived website

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ----
 
-The **Kobuki Core** stack consists of c++ libraries and utilities for working with a [Kobuki Robot](http:/kobuki.yujinrobot.com).
+The **Kobuki Core** stack consists of c++ libraries and utilities for working with a [Kobuki Robot](https://iclebo-kobuki.readthedocs.io/en/latest/).
 
 ----
 


### PR DESCRIPTION
Thanks for maintaining this code. I noticed that the original subdomain is not active: <http://kobuki.yujinrobot.com/>, so this pull request changes the README to point to the captured website in the Internet Archive.

I do not have any contacts at [Yujin Robot](https://yujinrobot.com/), but I think the ideal solution is to confirm with them that the website is offline and whether they want to bring it online again.